### PR TITLE
Use "SET *schema* TO" for Netezza

### DIFF
--- a/R/DatabaseConnector.R
+++ b/R/DatabaseConnector.R
@@ -228,7 +228,7 @@ connect.default <- function(dbms = "sql server", user, password, server, port, s
     driver <- jdbcSingleton("org.netezza.Driver", pathToJar, identifier.quote="`")
     connection <- RJDBC::dbConnect(driver, paste("jdbc:netezza://",host,":",port,"/",database,sep=""), user, password)
     if (!missing(schema) && !is.null(schema))
-      RJDBC::dbSendUpdate(connection,paste("SET search_path TO ",schema))
+      RJDBC::dbSendUpdate(connection,paste("SET schema TO ",schema))
     attr(connection,"dbms") <- dbms
     return(connection)
   }	


### PR DESCRIPTION
As @cgreich pointed out [here](https://github.com/OHDSI/DatabaseConnector/issues/1#issuecomment-72993357)
the correct syntax for Netezza is "SET schema TO ..." not "SET search_path TO ..."