### PR TITLE
Added optional MPP bulk loading to insertTable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: DatabaseConnector
 Type: Package
 Title: A Package for Connecting to Various DBMSs
-Version: 2.0.3
-Date: 2017-12-12
+Version: 2.0.4
+Date: 2018-02-16
 Author: Martijn J. Schuemie and Marc A. Suchard
 Maintainer: Martijn Schuemie <schuemie@ohdsi.org>
 Description: Package for connecting to various DBMSs. Also includes support for fetching data as ffdf objects.
@@ -13,7 +13,10 @@ Imports:
     ffbase (>= 0.12.1),
     SqlRender,
     methods,
-    utils
+    utils,
+    aws.s3,
+    uuid,
+    R.utils
 License: Apache License
 Suggests:
     testthat

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Features
   - Progress reporting
   - Multiple statements per query
 - Support for fetching data to ffdf objects
+- Insert data frame to a database table
 
 Examples
 ========
@@ -33,6 +34,26 @@ connectionDetails <- createConnectionDetails(dbms="mysql",
 conn <- connect(connectionDetails)
 querySql(conn,"SELECT COUNT(*) FROM person")
 disconnect(conn)
+```
+
+```r
+## regular data insert
+insertTable(connection = connection, 
+            tableName = "scratch.somedata", 
+            data = data, 
+            dropTableIfExists = TRUE, 
+            createTable = TRUE, 
+            tempTable = FALSE, 
+            useMppBulkLoad = FALSE)
+            
+## bulk data insert with Redshift or PDW
+insertTable(connection = connection, 
+            tableName = "scratch.somedata", 
+            data = data, 
+            dropTableIfExists = TRUE, 
+            createTable = TRUE, 
+            tempTable = FALSE, 
+            useMppBulkLoad = TRUE)
 ```
 
 Technology
@@ -50,6 +71,8 @@ Please note that this package requires Java to be installed. If you don't have J
 To be able to use Windows authentication for SQL Server, you have to install the JDBC driver. Download the .exe from [Microsoft](http://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=11774) and run it, thereby extracting its contents to a folder. In the extracted folder you will find the file sqljdbc_4.0/enu/auth/x64/sqljdbc_auth.dll (64-bits) or sqljdbc_4.0/enu/auth/x86/sqljdbc_auth.dll (32-bits), which needs to be moved to location on the system path, for example to c:/windows/system32.
 
 DatabaseConnector also depends on the OHDSI SqlRender package.
+
+For Redshift Bulk Mpp inserts, the cloudyR aws S3 pacakge is required.
 
 Getting Started
 ===============

--- a/inst/sql/sql_server/redshiftCopy.sql
+++ b/inst/sql/sql_server/redshiftCopy.sql
@@ -1,0 +1,4 @@
+COPY @qname
+FROM 's3://@s3RepoName/@pathToFiles/@fileName.gz'
+CREDENTIALS 'aws_access_key_id=@awsAccessKey;aws_secret_access_key=@awsSecretAccessKey'
+IGNOREHEADER AS 1 BLANKSASNULL EMPTYASNULL DELIMITER ',' csv quote as '`';

--- a/inst/sql/sql_server/redshiftCopy.sql
+++ b/inst/sql/sql_server/redshiftCopy.sql
@@ -1,4 +1,5 @@
 COPY @qname
-FROM 's3://@s3RepoName/@pathToFiles/@fileName.gz'
+FROM 's3://@s3RepoName/@pathToFiles/@fileName'
 CREDENTIALS 'aws_access_key_id=@awsAccessKey;aws_secret_access_key=@awsSecretAccessKey'
-IGNOREHEADER AS 1 BLANKSASNULL EMPTYASNULL DELIMITER ',' csv quote as '`';
+gzip
+IGNOREHEADER AS 1 BLANKSASNULL EMPTYASNULL DELIMITER ',' csv;

--- a/man/insertTable.Rd
+++ b/man/insertTable.Rd
@@ -5,7 +5,8 @@
 \title{Insert a table on the server}
 \usage{
 insertTable(connection, tableName, data, dropTableIfExists = TRUE,
-  createTable = TRUE, tempTable = FALSE, oracleTempSchema = NULL)
+  createTable = TRUE, tempTable = FALSE, oracleTempSchema = NULL,
+  useMppBulkLoad = FALSE)
 }
 \arguments{
 \item{connection}{The connection to the database server.}
@@ -22,6 +23,11 @@ insertTable(connection, tableName, data, dropTableIfExists = TRUE,
 
 \item{oracleTempSchema}{Specifically for Oracle, a schema with write priviliges where temp tables
 can be created.}
+
+\item{useMppBulkLoad}{If using Redshift or PDW, use more performant bulk loading techniques.
+Please note, Redshift requires valid S3 credentials; 
+PDW requires valid DWLoader installation. 
+Also, can only be used for permanent tables, and cannot be used to append to an existing table.}
 }
 \description{
 This function sends the data in a data frame or ffdf to a table on the server. Either a new table
@@ -30,6 +36,23 @@ is created, or the data is appended to an existing table.
 \details{
 This function sends the data in a data frame to a table on the server. Either a new table is
 created, or the data is appended to an existing table.
+
+If using Redshift or PDW, bulk uploading techniques may be more performant than relying upon 
+a batch of insert statements.
+
+Redshift: The MPP bulk loading relies upon the CloudyR S3 library to test a connection to an S3 bucket using
+AWS S3 credentials. Credentials are configured either directly into the System Environment
+using the following keys: 
+
+Sys.setenv("AWS_ACCESS_KEY_ID" = "some_access_key_id",
+           "AWS_SECRET_ACCESS_KEY" = "some_secret_access_key",
+           "AWS_DEFAULT_REGION" = "some_aws_region",
+           "AWS_BUCKET_NAME" = "some_bucket_name",
+           "AWS_OBJECT_KEY" = "some_object_key",
+           "AWS_SSE_TYPE" = "server_side_encryption_type")
+           
+PDW: The MPP bulk loading relies upon the client having a Windows OS and the DWLoader exe installed.
+Set the R environment variable DWLOADER_PATH to the location of the binary.
 }
 \examples{
 \dontrun{

--- a/man/insertTable.Rd
+++ b/man/insertTable.Rd
@@ -24,10 +24,11 @@ insertTable(connection, tableName, data, dropTableIfExists = TRUE,
 \item{oracleTempSchema}{Specifically for Oracle, a schema with write priviliges where temp tables
 can be created.}
 
-\item{useMppBulkLoad}{If using Redshift or PDW, use more performant bulk loading techniques.
+\item{useMppBulkLoad}{If using Redshift or PDW, use more performant bulk loading techniques. 
+Setting the system environment variable "USE_MPP_BULK_LOAD" to TRUE is another way to enable this mode.
 Please note, Redshift requires valid S3 credentials; 
 PDW requires valid DWLoader installation. 
-Also, can only be used for permanent tables, and cannot be used to append to an existing table.}
+This can only be used for permanent tables, and cannot be used to append to an existing table.}
 }
 \description{
 This function sends the data in a data frame or ffdf to a table on the server. Either a new table
@@ -38,7 +39,7 @@ This function sends the data in a data frame to a table on the server. Either a 
 created, or the data is appended to an existing table.
 
 If using Redshift or PDW, bulk uploading techniques may be more performant than relying upon 
-a batch of insert statements.
+a batch of insert statements, depending upon data size and network throughput.
 
 Redshift: The MPP bulk loading relies upon the CloudyR S3 library to test a connection to an S3 bucket using
 AWS S3 credentials. Credentials are configured either directly into the System Environment
@@ -60,10 +61,26 @@ connectionDetails <- createConnectionDetails(dbms = "mysql",
                                              server = "localhost",
                                              user = "root",
                                              password = "blah",
-                                             schema = "cdm_v4")
+                                             schema = "cdm_v5")
 conn <- connect(connectionDetails)
 data <- data.frame(x = c(1, 2, 3), y = c("a", "b", "c"))
 insertTable(conn, "my_table", data)
 disconnect(conn)
+
+## bulk data insert with Redshift or PDW
+connectionDetails <- createConnectionDetails(dbms = "redshift",
+                                             server = "localhost",
+                                             user = "root",
+                                             password = "blah",
+                                             schema = "cdm_v5")
+conn <- connect(connectionDetails)
+data <- data.frame(x = c(1, 2, 3), y = c("a", "b", "c"))
+insertTable(connection = connection, 
+            tableName = "scratch.somedata", 
+            data = data, 
+            dropTableIfExists = TRUE, 
+            createTable = TRUE, 
+            tempTable = FALSE, 
+            useMppBulkLoad = TRUE) # or, Sys.setenv("USE_MPP_BULK_LOAD" = TRUE)
 }
 }

--- a/tests/testthat/test-insertTable.R
+++ b/tests/testthat/test-insertTable.R
@@ -1,0 +1,33 @@
+library(testthat)
+
+test_that("PDW bulk load prerequisites not met", {
+  Sys.setenv("DWLOADER_PATH" = "")
+  connectionDetails <- createConnectionDetails(dbms = "redshift",
+                                               user = Sys.getenv("CDM5_PDW_USER"),
+                                               password = URLdecode(Sys.getenv("CDM5_PDW_PASSWORD")),
+                                               server = Sys.getenv("CDM5_PDW_SERVER"),
+                                               schema = Sys.getenv("CDM5_PDW_CDM_SCHEMA"))
+  connection <- connect(connectionDetails)
+  data <- data.frame(x = c(1, 2, 3), y = c("a", "b", "c"))
+  expect_error(object = insertTable(connection = connection, tableName = "scratch.dbo.test", data = data, 
+                                    dropTableIfExists = T, createTable = T, tempTable = F, useMppBulkLoad = T))
+})
+
+
+test_that("Redshift bulk load prerequisites not met", {
+  Sys.setenv("AWS_ACCESS_KEY_ID" = "",
+             "AWS_SECRET_ACCESS_KEY" = "",
+             "AWS_DEFAULT_REGION" = "",
+             "AWS_BUCKET_NAME" = "",
+             "AWS_OBJECT_KEY" = "",
+             "AWS_SSE_TYPE" = "")
+  connectionDetails <- createConnectionDetails(dbms = "redshift",
+                                     user = Sys.getenv("CDM5_REDSHIFT_USER"),
+                                     password = URLdecode(Sys.getenv("CDM5_REDSHIFT_PASSWORD")),
+                                     server = Sys.getenv("CDM5_REDSHIFT_SERVER"),
+                                     schema = Sys.getenv("CDM5_REDSHIFT_CDM_SCHEMA"))
+  connection <- connect(connectionDetails)
+  data <- data.frame(x = c(1, 2, 3), y = c("a", "b", "c"))
+  expect_error(object = insertTable(connection = connection, tableName = "scratch.test", data = data, 
+                                    dropTableIfExists = T, createTable = T, tempTable = F, useMppBulkLoad = T))
+})


### PR DESCRIPTION
As inserts on MPP systems like PDW and Redshift are very slow, I've added a new mode to the insertTable function. So as to not break insertTable, useMppBulkLoad is a new optional parameter, but can also be invoked via system environment variable ("USE_MPP_BULK_LOAD").

This mode uses the following method:
1. Verify prerequisites are in place; if this fails, error out and tell the user to review or switch to regular  mode.
2. For Redshift, this means having AWS S3 credentials stored in environment variables
3. For PDW, this means having the path to the DWLoader binary stored in an environment variable.
4. Store the data frame to local storage as a CSV and compress into gzip file for faster transfer over the network.
5. For Redshift, upload to AWS S3, run COPY command on Redshift
6. For PDW, invoke DWLoader
7. Remove the local files