### PR TITLE
Add bit64 package and code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     DatabaseConnectorJars,
     rJava,
     bit,
+    bit64,
     ff,
     ffbase (>= 0.12.1),
     SqlRender,

--- a/R/InsertTable.R
+++ b/R/InsertTable.R
@@ -185,12 +185,12 @@ ctasHack <- function(connection, qname, tempTable, varNames, fts, data, progress
 }
 
 is.bigint <- function(x) {
-  num <- 2^63
+  num <- bit64::as.integer64.integer64(2^63)  # range limit
   
   bigint.min <- -num
   bigint.max <- num - 1
   
-  return(!is.na(x) && is.numeric(x) && !is.factor(x) && x == round(x) &&  x >= bigint.min && x <= bigint.max)
+  return(x >= bigint.min && x <= bigint.max && bit64::is.vector.integer64(x))
 }
 
 #' Insert a table on the server


### PR DESCRIPTION
Fixed #81 
The code for BIGINT was modified using the integer64 data type provided in the bit64 package.

@schuemie  I have just completed testing against ```SQL Server```. Can you test against other DBMS?