### PR TITLE
Add support for Redshift temp table bulk load

### DIFF
--- a/R/InsertTable.R
+++ b/R/InsertTable.R
@@ -233,8 +233,8 @@ insertTable.default <- function(connection,
       data <- as.data.frame(data)
   }
   isSqlReservedWord(c(tableName, colnames(data)), warn = TRUE)
-  useBulkLoad <- (bulkLoad && connection@dbms == "hive" && createTable) ||
-    (bulkLoad && connection@dbms %in% c("redshift", "pdw", "postgresql") && !tempTable)
+  useBulkLoad <- (bulkLoad && connection@dbms %in% c("hive", "redshift") && createTable) ||
+    (bulkLoad && connection@dbms %in% c("pdw", "postgresql") && !tempTable)
   useCtasHack <- connection@dbms %in% c("pdw", "redshift", "bigquery", "hive") && createTable && nrow(data) > 0 && !useBulkLoad
   
   sqlDataTypes <- sapply(data, getSqlDataTypes)


### PR DESCRIPTION
Aims to address #139. I took a look at the tests in the repo and didn't see any for Redshift. As a result, I didn't add to this PR. However, I did create some code to test this out which I'll share here for feedback:

````r
library(DatabaseConnector)
redshiftDatabaseSettings <- createConnectionDetails(
  dbms = "redshift"
  ,server = <secret>
  ,extraSettings = <secret>
  ,port = <secret>
  ,user = <secret>
  ,password = <secret>
)
conn <- connect(connectionDetails = redshiftDatabaseSettings)

# select data and pull it back into R
myFirstQuery <- dbGetQuery(conn = conn, statement = "SELECT * FROM cdm.person LIMIT 1000;")

Sys.setenv(AWS_SSE_TYPE = <secret>)
Sys.setenv(AWS_BUCKET_NAME = <secret>)
Sys.setenv(AWS_OBJECT_KEY = <secret>)
Sys.setenv(AWS_ACCESS_KEY_ID = <secret>)
Sys.setenv(AWS_SECRET_ACCESS_KEY = <secret>)
Sys.setenv(AWS_DEFAULT_REGION = <secret>)

# Permanent table test
tableName <- "scratch_asena5.bulk_insert_full_table_test"
insertTable(connection = conn,
            tableName = tableName,
            data = myFirstQuery, 
            dropTableIfExists = TRUE,
            createTable = TRUE,
            tempTable = FALSE,
            bulkLoad = TRUE)

foo <- DatabaseConnector::dbGetQuery(conn, paste0("SELECT * FROM ", tableName, ";"))

# Temp table test
tableName <- "#sena_test"
insertTable(connection = conn,
            tableName = tableName, 
            data = myFirstQuery, 
            dropTableIfExists = TRUE,
            createTable = TRUE,
            tempTable = TRUE,
            bulkLoad = TRUE)
tempFoo <- DatabaseConnector::dbGetQuery(conn, paste0("SELECT * FROM ", tableName, ";"))
disconnect(conn)
````