### PR TITLE
Add some tests from the DBItest package

### DIFF
--- a/R/DBI.R
+++ b/R/DBI.R
@@ -103,7 +103,7 @@ setClass("DatabaseConnectorDbiConnection",
 #'                   user = "joe",
 #'                   password = "secret")
 #' querySql(conn, "SELECT * FROM cdm_synpuf.person;")
-#' dbDisconnet(conn)
+#' dbDisconnect(conn)
 #' }
 #'
 #' @export

--- a/R/Drivers.R
+++ b/R/Drivers.R
@@ -87,21 +87,27 @@ downloadJdbcDrivers <- function(dbms, pathToDriver = Sys.getenv("DATABASECONNECT
                        "sql server" = "sqlServerV9.2.0.zip",
                        "oracle" = "oracleV19.8.zip")
   
-  driverName <- jdbcDriverNames[[dbms]]
-  result <- download.file(url = paste0(baseUrl, driverName),
-                          destfile = paste(pathToDriver, driverName, sep = "/"),
-                          method = method)
-  
-  extractedFilename <- unzip(file.path(pathToDriver, driverName), exdir = pathToDriver)
-  unzipSuccess <- is.character(extractedFilename)
-  
-  if (unzipSuccess) {
-    file.remove(file.path(pathToDriver, driverName))
+  if (dbms == "all") {
+    dbms <- names(jdbcDriverNames)
   }
-  if (unzipSuccess && result == 0) { 
-    inform(paste0("DatabaseConnector JDBC drivers downloaded to '", pathToDriver, "'."))
-  } else {
-    abort(paste0("Downloading and unzipping of JDBC drivers to '", pathToDriver, "' has failed."))
+  
+  for(db in dbms) {
+    driverName <- jdbcDriverNames[[db]]
+    result <- download.file(url = paste0(baseUrl, driverName),
+                            destfile = paste(pathToDriver, driverName, sep = "/"),
+                            method = method)
+    
+    extractedFilename <- unzip(file.path(pathToDriver, driverName), exdir = pathToDriver)
+    unzipSuccess <- is.character(extractedFilename)
+    
+    if (unzipSuccess) {
+      file.remove(file.path(pathToDriver, driverName))
+    }
+    if (unzipSuccess && result == 0) { 
+      inform(paste0("DatabaseConnector ", db, " JDBC driver downloaded to '", pathToDriver, "'."))
+    } else {
+      abort(paste0("Downloading and unzipping of ", db, " JDBC driver to '", pathToDriver, "' has failed."))
+    }
   }
   
   invisible(pathToDriver)

--- a/tests/testthat/test-DBItest.R
+++ b/tests/testthat/test-DBItest.R
@@ -1,0 +1,40 @@
+# Run only DBI tests with testthat::test_file("tests/testthat/test-DBItest.R") 
+
+port <- Sys.getenv("CDM5_POSTGRESQL_PORT")
+if(port == "") port <- "5432"
+
+cdlist <- list(dbms = "postgresql",
+               server = Sys.getenv("CDM5_POSTGRESQL_SERVER"),
+               user = Sys.getenv("CDM5_POSTGRESQL_USER"),
+               password = Sys.getenv("CDM5_POSTGRESQL_PASSWORD"),
+               port = port)
+
+
+default_skip <- c("package_name")
+
+tweaks <- DBItest::tweaks(
+  constructor_name = "DatabaseConnectorDriver",
+  omit_blob_tests = TRUE
+)
+
+DBItest::make_context(
+  new(
+    "DBIConnector",
+    .drv = DatabaseConnector::DatabaseConnectorDriver(),
+    .conn_args = cdlist
+  ),
+  tweaks = tweaks,
+  default_skip = default_skip
+)
+
+
+DBItest::test_getting_started(skip = c(
+  "package_name" # DatabaseConnector package does not start with 'R'
+))
+
+
+DBItest::test_driver(skip = c(
+  "get_info_driver", # Need to implement dbGetInfo
+  "connect_bigint.*" # Possibly need to fix bigint tests
+))
+


### PR DESCRIPTION
This PR is a start at improving DatabaseConnector test coverage by adding tests implemented in the DBItest package. The relevant issue is #138. 

https://cran.r-project.org/web/packages/DBItest/vignettes/DBItest.html

I also found a bug in the downloadJdbcDrivers function which I fixed as well. Let me know if you want a separate PR for that bug. The issue is #147.

