### PR TITLE
Add ACCEPTINVCHARS option to redshift copy

### DIFF
--- a/inst/sql/sql_server/redshiftCopy.sql
+++ b/inst/sql/sql_server/redshiftCopy.sql
@@ -2,4 +2,4 @@ COPY @sqlTableName
 FROM 's3://@s3RepoName/@pathToFiles/@fileName'
 CREDENTIALS 'aws_access_key_id=@awsAccessKey;aws_secret_access_key=@awsSecretAccessKey'
 gzip
-IGNOREHEADER AS 1 BLANKSASNULL EMPTYASNULL DELIMITER ',' csv;
+IGNOREHEADER AS 1 BLANKSASNULL EMPTYASNULL ACCEPTINVCHARS DELIMITER ',' csv;


### PR DESCRIPTION
This addition bypasses UTF8 encoding errors when attempting to bulkload to redshift

Closes issue #166 

