### PR TITLE
Fix hive database connection -- closes #176

### DIFF
--- a/R/Connect.R
+++ b/R/Connect.R
@@ -511,7 +511,7 @@ connect <- function(connectionDetails = NULL,
   }
   if (dbms == "hive") {
     inform("Connecting using Hive driver")
-    jarPath <- findPathToJar("^hive-jdbc-standalone\\.jar$", pathToDriver)
+    jarPath <- findPathToJar("^hive-jdbc-[.0-9]*-standalone\\.jar$", pathToDriver)
     driver <- getJbcDriverSingleton("org.apache.hive.jdbc.HiveDriver", jarPath)
     
     if (missing(connectionString) || is.null(connectionString)) {

--- a/R/Connect.R
+++ b/R/Connect.R
@@ -511,7 +511,7 @@ connect <- function(connectionDetails = NULL,
   }
   if (dbms == "hive") {
     inform("Connecting using Hive driver")
-    jarPath <- findPathToJar("^hive-jdbc-[.0-9]*-standalone\\.jar$", pathToDriver)
+    jarPath <- findPathToJar("^hive-jdbc-([.0-9]+-)*standalone\\.jar$", pathToDriver)
     driver <- getJbcDriverSingleton("org.apache.hive.jdbc.HiveDriver", jarPath)
     
     if (missing(connectionString) || is.null(connectionString)) {

--- a/R/Connect.R
+++ b/R/Connect.R
@@ -19,6 +19,7 @@
 checkIfDbmsIsSupported <- function(dbms) {
   supportedDbmss <- c(
     "oracle",
+    "hive",
     "postgresql",
     "redshift",
     "sql server",

--- a/R/Connect.R
+++ b/R/Connect.R
@@ -515,7 +515,7 @@ connect <- function(connectionDetails = NULL,
     driver <- getJbcDriverSingleton("org.apache.hive.jdbc.HiveDriver", jarPath)
     
     if (missing(connectionString) || is.null(connectionString)) {
-      connectionString <- paste0("jdbc:hive2://", server, ":", port)
+      connectionString <- paste0("jdbc:hive2://", server, ":", port, "/")
       if (!missing(extraSettings) && !is.null(extraSettings)) {
         connectionString <- paste0(connectionString, ";", extraSettings)
       }


### PR DESCRIPTION
These changes make hive usable as a dbms connection option.

This includes 1) adding hive to the list of approved dbms and 2) adding a trailing slash to the hive connection string.

There is also a minor change to the regex used to find the hive standalone jar file so that the standard naming convention for this file (which includes the version number) is recognised.