### PR TITLE
Add dbms function

### DIFF
--- a/R/Connect.R
+++ b/R/Connect.R
@@ -695,3 +695,36 @@ setPathToDll <- function() {
     rJava::J("org.ohdsi.databaseConnector.Authentication")$addPathToJavaLibrary(pathToDll)
   }
 }
+
+#' Get the database platform from a connection
+#' 
+#' The SqlRender package provides functions that translate SQL from OHDSISQL to 
+#' a target SQL dialect. These function need the name of the database platform to 
+#' translate to. The `dbms` function returns the dbms for any DBI 
+#' connection that can be passed along to SqlRender translation functions (see example).
+#'
+#' @param connection A DBI (or DatabaseConnector) connection
+#'
+#' @return The name of the database (dbms) used by SqlRender
+#' @export
+#'
+#' @examples
+#' library(DatabaseConnector)
+#' con <- connect(dbms = "sqlite", server = ":memory:")
+#' dbms(con)
+#' #> [1] "sqlite"
+#' SqlRender::translate("DATEADD(d, 365, dateColumn)", targetDialect = dbms(con))
+#' #> "CAST(STRFTIME('%s', DATETIME(dateColumn, 'unixepoch', (365)||' days')) AS REAL)"
+#' disconnect(con)
+dbms <- function(connection) {
+  if(!is.null(attr(connection, "dbms"))) return(attr(connection, "dbms"))
+  
+  switch (class(connection),
+          'Microsoft SQL Server' = 'sql server',
+          'PqConnection' = 'postgresql',
+          'RedshiftConnection' = 'redshift',
+          'BigQueryConnection' = 'bigquery',
+          'duckdb_connection'  = 'duckdb'
+          # add mappings from various connection classes to dbms here
+  )
+}

--- a/R/Connect.R
+++ b/R/Connect.R
@@ -717,6 +717,8 @@ setPathToDll <- function() {
 #' #> "CAST(STRFTIME('%s', DATETIME(dateColumn, 'unixepoch', (365)||' days')) AS REAL)"
 #' disconnect(con)
 dbms <- function(connection) {
+  if(!inherits(connection, "DBIConnection")) abort("connection must be a DBIConnection")
+  
   if(!is.null(attr(connection, "dbms"))) return(attr(connection, "dbms"))
   
   switch (class(connection),

--- a/R/Connect.R
+++ b/R/Connect.R
@@ -698,7 +698,7 @@ setPathToDll <- function() {
 
 #' Get the database platform from a connection
 #' 
-#' The SqlRender package provides functions that translate SQL from OHDSISQL to 
+#' The SqlRender package provides functions that translate SQL from OHDSI-SQL to 
 #' a target SQL dialect. These function need the name of the database platform to 
 #' translate to. The `dbms` function returns the dbms for any DBI 
 #' connection that can be passed along to SqlRender translation functions (see example).
@@ -726,7 +726,8 @@ dbms <- function(connection) {
           'PqConnection' = 'postgresql',
           'RedshiftConnection' = 'redshift',
           'BigQueryConnection' = 'bigquery',
+          'SQLiteConnection' = 'sqlite',
           'duckdb_connection'  = 'duckdb'
-          # add mappings from various connection classes to dbms here
+          # add mappings from various DBI connection classes to SqlRender dbms here
   )
 }

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -10,6 +10,7 @@ test_that("Open and close connection", {
   )
   connection <- connect(details)
   expect_true(inherits(connection, "DatabaseConnectorConnection"))
+  expect_equal(dbms(connection), "postgresql")
   expect_true(disconnect(connection))
 
   # SQL Server --------------------------------------------------
@@ -21,6 +22,7 @@ test_that("Open and close connection", {
   )
   connection <- connect(details)
   expect_true(inherits(connection, "DatabaseConnectorConnection"))
+  expect_equal(dbms(connection), "sql server")
   expect_true(disconnect(connection))
 
   # Oracle --------------------------------------------------
@@ -32,6 +34,7 @@ test_that("Open and close connection", {
   )
   connection <- connect(details)
   expect_true(inherits(connection, "DatabaseConnectorConnection"))
+  expect_equal(dbms(connection), "oracle")
   expect_true(disconnect(connection))
 
   # RedShift  --------------------------------------------------
@@ -43,6 +46,7 @@ test_that("Open and close connection", {
   )
   connection <- connect(details)
   expect_true(inherits(connection, "DatabaseConnectorConnection"))
+  expect_equal(dbms(connection), "redshift")
   expect_true(disconnect(connection))
 })
 
@@ -227,6 +231,7 @@ test_that("Open and close connection using connection strings with separate user
   )
   connection <- connect(details)
   expect_true(inherits(connection, "DatabaseConnectorConnection"))
+  expect_equal(dbms(connection), "spark")
   expect_true(disconnect(connection))
 })
 
@@ -246,4 +251,28 @@ test_that("Error is thrown when forgetting password", {
     server = Sys.getenv("CDM5_POSTGRESQL_SERVER")
   )
   expect_error(connection <- connect(details), "Connection propery 'password' is NULL")
+})
+
+
+test_that("dbms function maps DBI connections to correct SQL dialect", {
+  
+  mappings <- c(
+    'Microsoft SQL Server' = 'sql server',
+    'PqConnection' = 'postgresql',
+    'RedshiftConnection' = 'redshift',
+    'BigQueryConnection' = 'bigquery',
+    'SQLiteConnection' = 'sqlite',
+    'duckdb_connection'  = 'duckdb')
+  
+  
+  for(i in seq_along(mappings)) {
+    driver <- names(mappings)[i]
+    dialect <- unname(mappings)[i]
+    mockConstructor <- setClass(driver, contains = "DBIConnection")
+    mockConnection <- mockConstructor()
+    expect_equal(dbms(mockConnection), dialect)
+    
+    # duckdb is not yet supported in the current release of SqlRender
+    if(dialect != "duckdb") expect_error(checkIfDbmsIsSupported(dbms(mockConnection)), NA)
+  }
 })


### PR DESCRIPTION
The dbms function is the first step in generalizing DatabaseConnector and OHDSI tools to use DBI connections. See #185 

It maps various DBI connection classes to the dbms types supported by SqlRender. For DatabaseConnectorConnections it simply returns the dbms slot.


@schuemie - Would it be possible to include this function in the next release?

If it looks good then I'll add tests so coverage does not decrease.