### PR TITLE
Add check for tempEmulationSchema when using bigquery.

### DIFF
--- a/R/InsertTable.R
+++ b/R/InsertTable.R
@@ -259,6 +259,9 @@ insertTable.default <- function(connection,
       data <- as.data.frame(data)
     }
   }
+  if (connection@dbms == "bigquery" && is.null(tempEmulationSchema)) {
+    abort("tempEmulationSchema is required to use insertTable with bigquery")
+  }
   isSqlReservedWord(c(tableName, colnames(data)), warn = TRUE)
   useBulkLoad <- (bulkLoad && connection@dbms %in% c("hive", "redshift") && createTable) ||
     (bulkLoad && connection@dbms %in% c("pdw", "postgresql") && !tempTable)


### PR DESCRIPTION
Addresses #201 by adding an explicit check for tempEmulationSchema when using insertTable with BigQuery.

We don't have unit tests for bigquery so no test was added.

