### PR TITLE
Remove Progress bar in unit tests

### DIFF
--- a/R/Sql.R
+++ b/R/Sql.R
@@ -400,7 +400,7 @@ supportsBatchUpdates <- function(connection) {
 executeSql <- function(connection,
                        sql,
                        profile = FALSE,
-                       progressBar = TRUE,
+                       progressBar = !Sys.getenv("TESTTHAT", unset = FALSE),
                        reportOverallTime = TRUE,
                        errorReportFile = file.path(getwd(), "errorReportSql.txt"),
                        runAsBatch = FALSE) {

--- a/R/Sql.R
+++ b/R/Sql.R
@@ -400,7 +400,7 @@ supportsBatchUpdates <- function(connection) {
 executeSql <- function(connection,
                        sql,
                        profile = FALSE,
-                       progressBar = !Sys.getenv("TESTTHAT", unset = FALSE),
+                       progressBar = !as.logical(Sys.getenv("TESTTHAT", unset = FALSE)),
                        reportOverallTime = TRUE,
                        errorReportFile = file.path(getwd(), "errorReportSql.txt"),
                        runAsBatch = FALSE) {

--- a/man/executeSql.Rd
+++ b/man/executeSql.Rd
@@ -8,7 +8,7 @@ executeSql(
   connection,
   sql,
   profile = FALSE,
-  progressBar = TRUE,
+  progressBar = !as.logical(Sys.getenv("TESTTHAT", unset = FALSE)),
   reportOverallTime = TRUE,
   errorReportFile = file.path(getwd(), "errorReportSql.txt"),
   runAsBatch = FALSE


### PR DESCRIPTION

The number of lines in github actions taken up by progress bars is often annoying and not particularly useful in this context.

This PR maintains the default behaviour (display a progress bar when `executeSql` is called) but uses the `TESTTHAT` environment variable when inside tests.