### PR TITLE
[DOCS] Removed deprecated and removed `schema` kwarg

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ Examples
 connectionDetails <- createConnectionDetails(dbms="postgresql", 
                                              server="localhost",
                                              user="root",
-                                             password="blah",
-                                             schema="cdm_v4")
+                                             password="blah")
 conn <- connect(connectionDetails)
 querySql(conn,"SELECT COUNT(*) FROM person")
 disconnect(conn)


### PR DESCRIPTION
Although I did not open an issue prior for this, this is a small docs fix and shouldn't require too much oversight. There was a bug in the docs referencing a deprecated kwarg in a function that was causing my code to error. I know the README is autogenerated (based on commit history) so where should this fix actually go?