### PR TITLE
Generalize querySql and executeSql so they work with any DBIConnection

### DIFF
--- a/tests/testthat/test-DBIConnection.R
+++ b/tests/testthat/test-DBIConnection.R
@@ -2,13 +2,14 @@ test_that("querySql and executeSql work with a duckdb DBIConnection", {
   conn <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   DBI::dbWriteTable(conn, "cars", cars)
   df <- querySql(conn, "select * from cars")
-  expect_equal(df, cars)
+  names(df) <- tolower(names(df))
+  expect_true(all.equal(df, cars))
   
-  expect_output(executeSql(conn, "
+  executeSql(conn, "
     CREATE TABLE test (column1 integer, column2 varchar);
     INSERT INTO test VALUES (1, 'a');
     INSERT INTO test VALUES (2, 'b');
-  "))
+  ")
   
   df <- querySql(conn, "select * from test")
   expect_s3_class(df, "data.frame")
@@ -21,19 +22,20 @@ test_that("querySql and executeSql work with a sqlite DBIConnection", {
   conn <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
   DBI::dbWriteTable(conn, "cars", cars)
   df <- querySql(conn, "select * from cars")
+  names(df) <- tolower(names(df))
   expect_equal(df, cars)
   
-  expect_output(executeSql(conn, "
+  executeSql(conn, "
     CREATE TABLE test (column1 integer, column2 varchar);
     INSERT INTO test VALUES (1, 'a');
     INSERT INTO test VALUES (2, 'b');
-  "))
+  ")
   
   df <- querySql(conn, "select * from test")
   expect_s3_class(df, "data.frame")
   expect_equal(nrow(df), 2)
   
-  DBI::dbDisconnect(conn)
+  DBI::dbDisconnect(conn, shutdown = TRUE)
 })
 
 

--- a/tests/testthat/test-DBIConnection.R
+++ b/tests/testthat/test-DBIConnection.R
@@ -1,0 +1,39 @@
+test_that("querySql and executeSql work with a duckdb DBIConnection", {
+  conn <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  DBI::dbWriteTable(conn, "cars", cars)
+  df <- querySql(conn, "select * from cars")
+  expect_equal(df, cars)
+  
+  expect_output(executeSql(conn, "
+    CREATE TABLE test (column1 integer, column2 varchar);
+    INSERT INTO test VALUES (1, 'a');
+    INSERT INTO test VALUES (2, 'b');
+  "))
+  
+  df <- querySql(conn, "select * from test")
+  expect_s3_class(df, "data.frame")
+  expect_equal(nrow(df), 2)
+  
+  DBI::dbDisconnect(conn)
+})
+
+test_that("querySql and executeSql work with a sqlite DBIConnection", {
+  conn <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
+  DBI::dbWriteTable(conn, "cars", cars)
+  df <- querySql(conn, "select * from cars")
+  expect_equal(df, cars)
+  
+  expect_output(executeSql(conn, "
+    CREATE TABLE test (column1 integer, column2 varchar);
+    INSERT INTO test VALUES (1, 'a');
+    INSERT INTO test VALUES (2, 'b');
+  "))
+  
+  df <- querySql(conn, "select * from test")
+  expect_s3_class(df, "data.frame")
+  expect_equal(nrow(df), 2)
+  
+  DBI::dbDisconnect(conn)
+})
+
+


### PR DESCRIPTION
This PR should allow querySql and executeSql to work with any DBIConnection. I've added tests for SQLite and duckdb that don't require the DatabaseConnectorDbiConnection wrapper class.