### PR TITLE
added date parsing taking into account the user's time zone

### DIFF
--- a/R/InsertTable.R
+++ b/R/InsertTable.R
@@ -336,6 +336,7 @@ insertTable.default <- function(connection,
       batchedInsert <- rJava::.jnew(
         "org.ohdsi.databaseConnector.BatchedInsert",
         connection@jConnection,
+        connection@dbms,
         insertSql,
         ncol(data),
         supportsAutoCommit(dbms)


### PR DESCRIPTION
fixes #223 
Snowflake uses client local time zone, so to get timestamp in UTC timezone we need to prepare date parser and use it instead of default Timezone.valueOf
This approach can be used only with snowflake, because other databases don't use timezone for timestamp