### PR TITLE
Duckdb path to driver

### DIFF
--- a/R/Drivers.R
+++ b/R/Drivers.R
@@ -162,7 +162,7 @@ getJbcDriverSingleton <- function(driverClass = "", classPath = "") {
 }
 
 checkPathToDriver <- function(pathToDriver, dbms) {
-  if (!is.null(dbms) && dbms %in% c("sqlite", "sqlite extended")) {
+  if (!is.null(dbms) && dbms %in% c("sqlite", "sqlite extended", "duckdb")) {
     return()
   }
   if (pathToDriver == "") {

--- a/tests/testthat/test-duckdb.R
+++ b/tests/testthat/test-duckdb.R
@@ -9,6 +9,20 @@ test_that("Open and close duckdb connection", {
   unlink(databaseFile)
 })
 
+test_that("Open and close duckdb without DATABASECONNECTOR_JAR_FOLDER", {
+  withr::with_envvar(
+    new=c("DATABASECONNECTOR_JAR_FOLDER"=""),
+    {
+    databaseFile <- tempfile()
+    connection <- DatabaseConnector::connect(dbms = "duckdb", server = databaseFile)
+    expect_s4_class(connection, "DatabaseConnectorDbiConnection")
+    disconnect(connection)
+    unlink(databaseFile)
+    }
+    
+  )
+})
+
 test_that("Insert and retrieve dates from duckdb", {
   databaseFile <- tempfile()
   connection <- DatabaseConnector::connect(dbms = "duckdb", server = databaseFile)


### PR DESCRIPTION
Fixes #253 
- Added an exception to `checkPathToDriver' for `duckdb` 
- Added a unit test where I temporarily unset JAR folder env variable and then try to connect to a duckdb database.