### PR TITLE
Postgres bulk load connection string

### DIFF
--- a/R/BulkLoad.R
+++ b/R/BulkLoad.R
@@ -308,7 +308,7 @@ bulkLoadPostgres <- function(connection, sqlTableName, sqlFieldNames, sqlDataTyp
       "getMetaData"
     )
     server <- rJava::.jcall(databaseMetaData, "Ljava/lang/String;", "getURL")
-    server <- strsplit(server, "//")[[2]]
+    server <- strsplit(server, "//")[[1]][2]
   }
 
   hostServerDb <- strsplit(server, "/")[[1]]

--- a/R/BulkLoad.R
+++ b/R/BulkLoad.R
@@ -299,7 +299,19 @@ bulkLoadPostgres <- function(connection, sqlTableName, sqlFieldNames, sqlDataTyp
   readr::write_excel_csv(data, csvFileName, na = "")
   on.exit(unlink(csvFileName))
 
-  hostServerDb <- strsplit(attr(connection, "server")(), "/")[[1]]
+  server <- attr(connection, "server")()
+  if (is.null(server)) {
+    # taken directly from DatabaseConnector R/RStudio.R - getServer.default, could an attr too?
+    databaseMetaData <- rJava::.jcall(
+      connection@jConnection,
+      "Ljava/sql/DatabaseMetaData;",
+      "getMetaData"
+    )
+    server <- rJava::.jcall(databaseMetaData, "Ljava/lang/String;", "getURL")
+    server <- strsplit(server, "//")[[2]]
+  }
+
+  hostServerDb <- strsplit(server, "/")[[1]]
   port <- attr(connection, "port")()
   user <- attr(connection, "user")()
   password <- attr(connection, "password")()


### PR DESCRIPTION
This allows a call to the psql binary executable when using a connection string. 

The assumption this makes is that the connection string is always of the form:

`"jdbc:postgresql://<server>/<database>"`

It may be more appropriate to refactor server loading so that the connection `server` attr is always consistently set?