### PR TITLE
add noSplit option to executeSql

### DIFF
--- a/R/Sql.R
+++ b/R/Sql.R
@@ -396,7 +396,8 @@ executeSql <- function(connection,
                        progressBar = !as.logical(Sys.getenv("TESTTHAT", unset = FALSE)),
                        reportOverallTime = TRUE,
                        errorReportFile = file.path(getwd(), "errorReportSql.txt"),
-                       runAsBatch = FALSE) {
+                       runAsBatch = FALSE,
+                       noSplit = FALSE) {
   if (inherits(connection, "DatabaseConnectorJdbcConnection") && rJava::is.jnull(connection@jConnection)) {
     abort("Connection is closed")
   }
@@ -414,7 +415,11 @@ executeSql <- function(connection,
   }
   
   batched <- runAsBatch && supportsBatchUpdates(connection)
-  sqlStatements <- SqlRender::splitSql(sql)
+  if (noSplit) { # can prob. replace this block with `sqlStatements <- ifelse(noSplit, sql ,SqlRender::splitSql(sql))`
+    sqlStatements <- sql
+  } else {
+    sqlStatements <- SqlRender::splitSql(sql)
+  }
   rowsAffected <- c()
   if (batched) {
     batchSize <- 1000

--- a/R/Sql.R
+++ b/R/Sql.R
@@ -415,8 +415,8 @@ executeSql <- function(connection,
   }
   
   batched <- runAsBatch && supportsBatchUpdates(connection)
-  if (noSplit) { # can prob. replace this block with `sqlStatements <- ifelse(noSplit, sql ,SqlRender::splitSql(sql))`
-    sqlStatements <- sql
+  if (noSplit) { # can prob. replace this block with `sqlStatements <- ifelse(noSplit, unlist(sql) ,SqlRender::splitSql(sql))`
+    sqlStatements <- unlist(sql) # splitSql outputs a vector of character stings, so we should do the same
   } else {
     sqlStatements <- SqlRender::splitSql(sql)
   }


### PR DESCRIPTION
This allows for multi-statement execution "at once" for non-Oracle DBMSes and/or for pre-split content.

Specifically this is made to work around issues with `sqlRender::splitSql` where valid single (but compound) SQL statements are broken into multiple statements that are syntactically invalid on their own. This was observed when trying run `executeSql` on a `CREATE PROCEDURE` statement.  [Please see this issue ](https://github.com/OHDSI/SqlRender/issues/381)
