### PR TITLE
Adding bulk load for Spark (DataBricks)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,8 @@ Suggests:
     odbc,
     duckdb,
     pool,
-    ParallelLogger
+    ParallelLogger,
+    AzureStor
 License: Apache License
 VignetteBuilder: knitr
 URL: https://ohdsi.github.io/DatabaseConnector/, https://github.com/OHDSI/DatabaseConnector

--- a/DatabaseConnector.Rproj
+++ b/DatabaseConnector.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 9d51e576-41a3-432f-b696-8bfdc3eed676
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/R/InsertTable.R
+++ b/R/InsertTable.R
@@ -121,6 +121,13 @@ validateInt64Insert <- function() {
 #' "some_aws_region", "AWS_BUCKET_NAME" = "some_bucket_name", "AWS_OBJECT_KEY" = "some_object_key",
 #' "AWS_SSE_TYPE" = "server_side_encryption_type").
 #'
+#' Spark (DataBricks): The MPP bulk loading relies upon the AzureStor library
+#' to test a connection to an Azure ADLS Gen2 storage container using Azure credentials. 
+#' Credentials are configured directly into the System Environment using the 
+#' following keys: Sys.setenv("AZR_STORAGE_ACCOUNT" =
+#' "some_azure_storage_account", "AZR_ACCOUNT_KEY" = "some_secret_account_key", "AZR_CONTAINER_NAME" =
+#' "some_container_name").
+#'
 #' PDW: The MPP bulk loading relies upon the client
 #' having a Windows OS and the DWLoader exe installed, and the following permissions granted: --Grant
 #' BULK Load permissions - needed at a server level USE master; GRANT ADMINISTER BULK OPERATIONS TO
@@ -308,6 +315,8 @@ insertTable.default <- function(connection,
       bulkLoadHive(connection, sqlTableName, sqlFieldNames, data)
     } else if (dbms == "postgresql") {
       bulkLoadPostgres(connection, sqlTableName, sqlFieldNames, sqlDataTypes, data)
+    } else if (dbms == "spark") {
+      bulkLoadSpark(connection, sqlTableName, data)
     }
   } else if (useCtasHack) {
     # Inserting using CTAS hack ----------------------------------------------------------------

--- a/extras/TestBulkLoad.R
+++ b/extras/TestBulkLoad.R
@@ -114,3 +114,37 @@ all.equal(data, data2)
 
 renderTranslateExecuteSql(connection, "DROP TABLE scratch_mschuemi.insert_test;")
 disconnect(connection)
+
+
+# Spark ------------------------------------------------------------------------------
+# Assumes Spark (DataBricks) environmental variables have been set
+options(sqlRenderTempEmulationSchema = Sys.getenv("DATABRICKS_SCRATCH_SCHEMA"))
+databricksConnectionString <- paste0("jdbc:databricks://", Sys.getenv('DATABRICKS_HOST'), "/default;transportMode=http;ssl=1;AuthMech=3;httpPath=", Sys.getenv('DATABRICKS_HTTP_PATH'))
+connectionDetails <- createConnectionDetails(dbms = "spark",
+                                             connectionString = databricksConnectionString,
+                                             user = "token",
+                                             password = Sys.getenv("DATABRICKS_TOKEN"))
+
+
+connection <- connect(connectionDetails)
+system.time(
+  insertTable(connection = connection,
+              tableName = "scratch.scratch_asena5.insert_test",
+              data = data,
+              dropTableIfExists = TRUE,
+              createTable = TRUE,
+              tempTable = FALSE,
+              progressBar = TRUE,
+              camelCaseToSnakeCase = TRUE,
+              bulkLoad = TRUE)
+)
+data2 <- querySql(connection, "SELECT * FROM scratch.scratch_asena5.insert_test;", snakeCaseToCamelCase = TRUE, integer64AsNumeric = FALSE)
+
+data <- data[order(data$id), ]
+data2 <- data2[order(data2$id), ]
+row.names(data) <- NULL
+row.names(data2) <- NULL
+all.equal(data, data2)
+
+renderTranslateExecuteSql(connection, "DROP TABLE scratch.scratch_asena5.insert_test;")
+disconnect(connection)

--- a/inst/sql/sql_server/sparkCopy.sql
+++ b/inst/sql/sql_server/sparkCopy.sql
@@ -1,0 +1,10 @@
+COPY INTO @sqlTableName
+FROM 'abfss://@azureStorageAccount.dfs.core.windows.net/@fileName'
+WITH (
+ CREDENTIAL (AZURE_SAS_TOKEN = '@azureAccountKey')
+)
+FILEFORMAT = CSV
+FORMAT_OPTIONS (
+   'header' = 'true',
+   'inferSchema' = 'true'
+);


### PR DESCRIPTION
Aims to address #300 by adding support for bulk loading data into DataBricks.

For reference: https://learn.microsoft.com/en-us/azure/databricks/ingestion/cloud-object-storage/copy-into/tutorial-dbsql

