### PR TITLE
fix empty schema list for InterSystems IRIS in RStudio connection bro…

### DIFF
--- a/R/RStudio.R
+++ b/R/RStudio.R
@@ -76,7 +76,7 @@ unregisterWithRStudio <- function(connection) {
 }
 
 hasCatalogs <- function(connection) {
-  return(dbms(connection) %in% c("pdw", "postgresql", "sql server", "synapse", "redshift", "snowflake", "spark", "bigquery", "duckdb", "iris"))
+  return(dbms(connection) %in% c("pdw", "postgresql", "sql server", "synapse", "redshift", "snowflake", "spark", "bigquery", "duckdb"))
 }
 
 listDatabaseConnectorColumns <- function(connection,


### PR DESCRIPTION
this PR fixes an oversight in the initial submission for InterSystems IRIS support in `R/RStudio.R`, where the new database type was inadvertently added to the `hasCatalogs()` output. This led to the connection browser in RStudio showing up empty.
InterSystems IRIS does not use a catalog level (but has "namespaces", implied by the connection string), so removing it from that list.